### PR TITLE
Use common eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,30 +1,3 @@
 {
-    "env": {
-        "browser": false,
-        "es6": true,
-        "node": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": 2018,
-        "sourceType": "module"
-    },
-    "rules": {
-        "indent": [
-            "error",
-            4
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
-    }
+    "extends": "@slimonitor/eslint-config"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -774,6 +774,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@slimonitor/eslint-config": {
+      "version": "git+https://github.com/Slimonitor/eslint-config.git#9c7c3991f20565d173497644ef8bc19a81392482",
+      "from": "git+https://github.com/Slimonitor/eslint-config.git",
+      "dev": true
+    },
     "acorn": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
+    "@slimonitor/eslint-config": "git+https://github.com/Slimonitor/eslint-config.git",
     "eslint": "^5.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
This pull requests offers common eslint configuration, declared in [Slimonitor/eslint-config](https://github.com/Slimonitor/eslint-config/blob/master/index.js) repository. The aim is to preserve consistency of code style between server and host repositories.

Currently it extends recommended ruleset extended with spaces indentation. Complete list of eslint rules can be found in [documentation](https://eslint.org/docs/rules/).

After merging and pulling, execute `npm i` to install new dependency.